### PR TITLE
Update TVGuide Parsing

### DIFF
--- a/custom_components/xmltv_epg/api.py
+++ b/custom_components/xmltv_epg/api.py
@@ -39,7 +39,7 @@ class XMLTVClient:
             response = await self._session.get(url=self._url, timeout=10)
             response.raise_for_status()
 
-            if response.content_type == "text/xml":
+            if response.content_type in [ "text/xml", "application/xml" ]:
                 # raw XML text, read as-is
                 data = await response.text()
 

--- a/custom_components/xmltv_epg/api.py
+++ b/custom_components/xmltv_epg/api.py
@@ -39,7 +39,7 @@ class XMLTVClient:
             response = await self._session.get(url=self._url, timeout=10)
             response.raise_for_status()
 
-            if response.content_type in [ "text/xml", "application/xml" ]:
+            if response.content_type in ["text/xml", "application/xml"]:
                 # raw XML text, read as-is
                 data = await response.text()
 

--- a/custom_components/xmltv_epg/model/guide.py
+++ b/custom_components/xmltv_epg/model/guide.py
@@ -45,6 +45,10 @@ class TVGuide:
         generator_name = xml.attrib.get("generator-info-name")
         generator_url = xml.attrib.get("generator-info-url")
 
+        # seen in https://github.com/shadow578/homeassistant_xmltv-epg/issues/32
+        if generator_name is None:
+            generator_name = xml.attrib.get("source-info-name")
+
         # create guide instance
         guide = cls(generator_name, generator_url)
 

--- a/custom_components/xmltv_epg/model/program.py
+++ b/custom_components/xmltv_epg/model/program.py
@@ -10,6 +10,46 @@ if TYPE_CHECKING:
     from .channel import TVChannel
 
 
+def parse_episode_number(xml: ET.Element) -> str | None:
+    """Parse episode number from XML node to a readable format."""
+    episode_nums = {}
+    for episode_num in xml.findall("episode-num"):
+        system = episode_num.attrib.get("system")
+        content = episode_num.text
+        if system is not None and content is not None:
+            episode_nums[system] = episode_num.text
+    
+    # prefer Season+Episode format
+    if "SxxExx" in episode_nums:
+        return episode_nums["SxxExx"]
+
+    # fallback to xmltv_ns format, reformatted to 'S{season}E{episode}'
+    # xmltv_ns format is '0.0.' for 'S1E1'
+    # alternative format is '.0.' for episode only
+    if "xmltv_ns" in episode_nums:
+        episode = episode_nums["xmltv_ns"]
+        s, e, _ = episode.split(".")
+        
+        if s and e:
+            # Season+Episode format
+            s = int(s) + 1
+            e = int(e) + 1
+            return f"S{s}E{e}"
+        elif s:
+            # Season only format (technically invalid, but still)
+            s = int(s) + 1
+            return f"S{s}"
+        elif e:
+            # Episode only format
+            e = int(e) + 1
+            return f"E{e}"
+    
+    # fallback to any other format
+    for episode_num in episode_nums.values():
+        return episode_num
+    
+    return None
+
 class TVProgram:
     """TV Program Class."""
 
@@ -141,7 +181,7 @@ class TVProgram:
         # get and validate program info
         title = get_child_as_text(xml, "title")
         description = get_child_as_text(xml, "desc")
-        episode = get_child_as_text(xml, "episode-num")
+        episode = parse_episode_number(xml)
         subtitle = get_child_as_text(xml, "sub-title")
 
         if is_none_or_whitespace(title) or is_none_or_whitespace(description):

--- a/custom_components/xmltv_epg/model/program.py
+++ b/custom_components/xmltv_epg/model/program.py
@@ -18,7 +18,7 @@ def parse_episode_number(xml: ET.Element) -> str | None:
         content = episode_num.text
         if system is not None and content is not None:
             episode_nums[system] = episode_num.text
-    
+
     # prefer Season+Episode format
     if "SxxExx" in episode_nums:
         return episode_nums["SxxExx"]
@@ -29,7 +29,7 @@ def parse_episode_number(xml: ET.Element) -> str | None:
     if "xmltv_ns" in episode_nums:
         episode = episode_nums["xmltv_ns"]
         s, e, _ = episode.split(".")
-        
+
         if s and e:
             # Season+Episode format
             s = int(s) + 1
@@ -43,12 +43,13 @@ def parse_episode_number(xml: ET.Element) -> str | None:
             # Episode only format
             e = int(e) + 1
             return f"E{e}"
-    
+
     # fallback to any other format
     for episode_num in episode_nums.values():
         return episode_num
-    
+
     return None
+
 
 class TVProgram:
     """TV Program Class."""

--- a/test/model/test_TVProgram.py
+++ b/test/model/test_TVProgram.py
@@ -31,8 +31,10 @@ def test_from_xml():
 
 
 def test_episode_num_system_season_episode():
-    """Test TVProgram.from_xml parses episode_num in SxxExx format, 
-    as seen in https://github.com/shadow578/homeassistant_xmltv-epg/issues/32."""
+    """Test TVProgram.from_xml parses episode_num in SxxExx format.
+
+    as seen in https://github.com/shadow578/homeassistant_xmltv-epg/issues/32
+    """
     xml = ET.fromstring(
         '<programme start="20200101010000 +0000" stop="20200101020000 +0000" channel="CH1"><title>Program 1</title><desc>Description 1</desc><episode-num system="SxxExx">S13E7</episode-num></programme>'
     )
@@ -42,6 +44,7 @@ def test_episode_num_system_season_episode():
 
     # episode number '12.6.' should be converted to 'S13E7'
     assert program.episode == "S13E7"
+
 
 def test_episode_num_system_xmltv_ns():
     """Test TVProgram.from_xml parses episode_num in xmltv_ns format."""
@@ -181,7 +184,7 @@ def test_parse_episode_number_xmltv_ns_full():
     )
 
     episode = parse_episode_number(xml)
-    assert episode == "S01E02"
+    assert episode == "S1E2"
 
 
 def test_parse_episode_number_xmltv_ns_season_only():
@@ -191,7 +194,8 @@ def test_parse_episode_number_xmltv_ns_season_only():
     )
 
     episode = parse_episode_number(xml)
-    assert episode == "S01"
+    assert episode == "S1"
+
 
 def test_parse_episode_number_xmltv_ns_episode_only():
     """Test the parse_episode_number function works for tvxml_ns Episode only format."""
@@ -200,7 +204,7 @@ def test_parse_episode_number_xmltv_ns_episode_only():
     )
 
     episode = parse_episode_number(xml)
-    assert episode == "E02"
+    assert episode == "E2"
 
 
 def test_parse_episode_number_order():


### PR DESCRIPTION
fixes parsing issues described in #32 .

additionally updates the way that the episode-num field is parsed, with added test cases.