### PR TITLE
Update Dependencies, minor changes

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "ludeeus/integration_blueprint",
-    "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/python:3.13",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123
@@ -14,29 +14,36 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-python.python",
+                "charliermarsh.ruff",
                 "github.vscode-pull-request-github",
-                "ryanluker.vscode-coverage-gutters",
-                "ms-python.vscode-pylance"
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ryanluker.vscode-coverage-gutters"
             ],
             "settings": {
                 "files.eol": "\n",
                 "editor.tabSize": 4,
-                "python.pythonPath": "/usr/bin/python3",
-                "python.analysis.autoSearchPaths": false,
-                "python.linting.pylintEnabled": true,
-                "python.linting.enabled": true,
-                "python.formatting.provider": "black",
-                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-                "editor.formatOnPaste": false,
+                "editor.formatOnPaste": true,
                 "editor.formatOnSave": true,
-                "editor.formatOnType": true,
-                "files.trimTrailingWhitespace": true
+                "editor.formatOnType": false,
+                "files.trimTrailingWhitespace": true,
+                "python.analysis.typeCheckingMode": "basic",
+                "python.analysis.autoImportCompletions": true,
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff"
+                }
             }
         }
     },
     "remoteUser": "vscode",
     "features": {
-        "ghcr.io/devcontainers/features/rust:1": {}
+        "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+            "packages": [
+                "ffmpeg",
+                "libturbojpeg0",
+                "libpcap-dev"
+            ]
+        }
     }
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v5.3.0
           with:
-            python-version: "3.11"
+            python-version: "3.13"
             cache: "pip"
 
         - name: "Install requirements"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v5.3.0
           with:
-            python-version: "3.11"
+            python-version: "3.13"
             cache: "pip"
 
         - name: "Install requirements"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: auto
+        threshold: 5%

--- a/custom_components/xmltv_epg/api.py
+++ b/custom_components/xmltv_epg/api.py
@@ -36,7 +36,7 @@ class XMLTVClient:
         """Fetch XMLTV Guide data."""
         try:
             # fetch data
-            response = await self._session.get(url=self._url, timeout=10)
+            response = await self._session.get(url=self._url)
             response.raise_for_status()
 
             if response.content_type in ["text/xml", "application/xml"]:

--- a/custom_components/xmltv_epg/config_flow.py
+++ b/custom_components/xmltv_epg/config_flow.py
@@ -80,7 +80,7 @@ class XMLTVFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not guide:
             raise XMLTVClientCommunicationError("No data received")
 
-        return guide.generator_name
+        return guide.generator_name or ""
 
     @staticmethod
     def async_get_options_flow(config_entry: config_entries.ConfigEntry):

--- a/custom_components/xmltv_epg/config_flow.py
+++ b/custom_components/xmltv_epg/config_flow.py
@@ -33,7 +33,7 @@ class XMLTVFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self,
         user_input: dict | None = None,
-    ) -> config_entries.FlowResult:
+    ) -> config_entries.ConfigFlowResult:
         """Handle a flow initialized by the user."""
         _errors = {}
         if user_input is not None:
@@ -85,7 +85,7 @@ class XMLTVFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     def async_get_options_flow(config_entry: config_entries.ConfigEntry):
         """Get options flow handler."""
-        return XMLTVOptionsFlowHandler(config_entry)
+        return XMLTVOptionsFlowHandler()
 
 
 class XMLTVOptionsFlowHandler(config_entries.OptionsFlow):
@@ -93,19 +93,18 @@ class XMLTVOptionsFlowHandler(config_entries.OptionsFlow):
 
     VERSION = 1
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize XMLTV options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict | None = None
-    ) -> config_entries.FlowResult:
+    ) -> config_entries.ConfigFlowResult:
         """XMLTV Options Flow."""
         return await self.async_step_menu(user_input)
 
     async def async_step_menu(
         self, user_input: dict | None = None
-    ) -> config_entries.FlowResult:
+    ) -> config_entries.ConfigFlowResult:
         """XMLTV Options Flow."""
         if user_input is not None:
             return self.async_create_entry(

--- a/custom_components/xmltv_epg/coordinator.py
+++ b/custom_components/xmltv_epg/coordinator.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
+from custom_components.xmltv_epg.model.guide import TVGuide
+
 from .api import (
     XMLTVClient,
     XMLTVClientError,
@@ -23,6 +25,7 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from XMLTV."""
 
     config_entry: ConfigEntry
+    data: TVGuide
 
     def __init__(
         self,
@@ -90,7 +93,7 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
         return self.actual_now + self._lookahead
 
     @property
-    def last_update_time(self) -> datetime:
+    def last_update_time(self) -> datetime | None:
         """Get last update time."""
         return self._last_refetch_time
 

--- a/custom_components/xmltv_epg/coordinator.py
+++ b/custom_components/xmltv_epg/coordinator.py
@@ -27,6 +27,7 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(
         self,
         hass: HomeAssistant,
+        config_entry: ConfigEntry,
         client: XMLTVClient,
         update_interval: int,
         lookahead: int,
@@ -41,6 +42,7 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
             logger=LOGGER,
             name=DOMAIN,
             update_interval=timedelta(seconds=SENSOR_REFRESH_INTERVAL),
+            config_entry=config_entry,
         )
 
         self._guide = None

--- a/custom_components/xmltv_epg/model/channel.py
+++ b/custom_components/xmltv_epg/model/channel.py
@@ -42,6 +42,13 @@ class TVChannel:
 
         return None
 
+    def get_last_program(self) -> TVProgram | None:
+        """Get last program entry."""
+        if len(self.programs) == 0:
+            return None
+
+        return self.programs[-1]
+
     @classmethod
     def from_xml(cls, xml: ET.Element) -> "TVChannel | None":
         """Initialize TV Channel from XML Node, if possible.

--- a/custom_components/xmltv_epg/model/channel.py
+++ b/custom_components/xmltv_epg/model/channel.py
@@ -2,6 +2,7 @@
 
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from typing import cast
 
 from .helper import get_child_as_text, is_none_or_whitespace
 from .program import TVProgram
@@ -16,7 +17,7 @@ class TVChannel:
         """Initialize TV Channel."""
         self.id = id
         self.name = name
-        self.programs = []
+        self.programs: list[TVProgram] = []
 
     def add_program(self, program: TVProgram):
         """Add a program to channel."""
@@ -25,7 +26,7 @@ class TVChannel:
         # keep programs sorted by start time
         self.programs.sort(key=lambda p: p.start)
 
-    def get_current_program(self, time: datetime) -> TVProgram:
+    def get_current_program(self, time: datetime) -> TVProgram | None:
         """Get current program at given time."""
         for program in self.programs:
             if program.start.timestamp() <= time.timestamp() < program.end.timestamp():
@@ -33,7 +34,7 @@ class TVChannel:
 
         return None
 
-    def get_next_program(self, time: datetime) -> TVProgram:
+    def get_next_program(self, time: datetime) -> TVProgram | None:
         """Get next program after given time."""
         for program in self.programs:
             if program.start.timestamp() >= time.timestamp():
@@ -42,7 +43,7 @@ class TVChannel:
         return None
 
     @classmethod
-    def from_xml(cls, xml: ET.Element) -> "TVChannel":
+    def from_xml(cls, xml: ET.Element) -> "TVChannel | None":
         """Initialize TV Channel from XML Node, if possible.
 
         :param xml: XML Node
@@ -62,10 +63,12 @@ class TVChannel:
         id = xml.attrib.get("id")
         if is_none_or_whitespace(id):
             return None
+        id = cast(str, id)
 
         name = get_child_as_text(xml, "display-name")
         if is_none_or_whitespace(name):
             return None
+        name = cast(str, name)
 
         # remove 'XX: ' prefix from name, if present
         if len(name) > 4 and name[2] == ":" and name[3] == " ":  # 'XX: '

--- a/custom_components/xmltv_epg/model/guide.py
+++ b/custom_components/xmltv_epg/model/guide.py
@@ -11,20 +11,22 @@ class TVGuide:
 
     TAG = "tv"
 
-    def __init__(self, generator_name: str = None, generator_url: str = None):
+    def __init__(
+        self, generator_name: str | None = None, generator_url: str | None = None
+    ):
         """Initialize TV Guide."""
         self.generator_name = generator_name
         self.generator_url = generator_url
 
-        self.channels = []
-        self.programs = []
+        self.channels: list[TVChannel] = []
+        self.programs: list[TVProgram] = []
 
-    def get_channel(self, channel_id: str) -> TVChannel:
+    def get_channel(self, channel_id: str) -> TVChannel | None:
         """Get channel by ID."""
         return next((c for c in self.channels if c.id == channel_id), None)
 
     @classmethod
-    def from_xml(cls, xml: ET.Element) -> "TVGuide":
+    def from_xml(cls, xml: ET.Element) -> "TVGuide | None":
         """Initialize TV Guide from XML Node, if possible.
 
         :param xml: XML Node

--- a/custom_components/xmltv_epg/model/helper.py
+++ b/custom_components/xmltv_epg/model/helper.py
@@ -3,12 +3,12 @@
 import xml.etree.ElementTree as ET
 
 
-def is_none_or_whitespace(s: str) -> bool:
+def is_none_or_whitespace(s: str | None) -> bool:
     """Check if string is None, empty, or whitespace."""
     return s is None or not isinstance(s, str) or len(s.strip()) == 0
 
 
-def get_child_as_text(parent: ET.Element, tag: str) -> str:
+def get_child_as_text(parent: ET.Element, tag: str) -> str | None:
     """Get child node text as string, or None if not found."""
     node = parent.find(tag)
     return node.text if node is not None else None

--- a/custom_components/xmltv_epg/model/program.py
+++ b/custom_components/xmltv_epg/model/program.py
@@ -2,7 +2,7 @@
 
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .helper import get_child_as_text, is_none_or_whitespace
 
@@ -63,8 +63,8 @@ class TVProgram:
         end: datetime,
         title: str,
         description: str,
-        episode: str = None,
-        subtitle: str = None,
+        episode: str | None = None,
+        subtitle: str | None = None,
     ):
         """Initialize TV Program."""
         if end <= start:
@@ -140,7 +140,7 @@ class TVProgram:
         return title
 
     @classmethod
-    def from_xml(cls, xml: ET.Element) -> "TVProgram":
+    def from_xml(cls, xml: ET.Element) -> "TVProgram | None":
         """Initialize TV Program from XML Node, if possible.
 
         Cross-link is not done here, call cross_link_channel() after all programs are created.
@@ -166,6 +166,8 @@ class TVProgram:
         end = xml.attrib.get("stop")
         if is_none_or_whitespace(start) or is_none_or_whitespace(end):
             return None
+        start = cast(str, start)
+        end = cast(str, end)
 
         # parse start and end times
         try:
@@ -178,6 +180,7 @@ class TVProgram:
         channel_id = xml.attrib.get("channel")
         if is_none_or_whitespace(channel_id):
             return None
+        channel_id = cast(str, channel_id)
 
         # get and validate program info
         title = get_child_as_text(xml, "title")
@@ -187,6 +190,8 @@ class TVProgram:
 
         if is_none_or_whitespace(title) or is_none_or_whitespace(description):
             return None
+        title = cast(str, title)
+        description = cast(str, description)
 
         try:
             return cls(channel_id, start, end, title, description, episode, subtitle)

--- a/custom_components/xmltv_epg/sensor.py
+++ b/custom_components/xmltv_epg/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -27,7 +28,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
     )
 
     # setup sensor for coordinator status
-    sensors = [XMLTVStatusSensor(coordinator, guide)]
+    sensors: list[SensorEntity] = [XMLTVStatusSensor(coordinator, guide)]
 
     # add current / upcoming program sensors for each channel
     for channel in guide.channels:
@@ -64,6 +65,8 @@ class XMLTVChannelSensor(XMLTVEntity, SensorEntity):
         entity_id = f"sensor.{normalize_for_entity_id(channel.id)}_{translation_key}"
 
         return translation_key, entity_id
+
+    coordinator: XMLTVDataUpdateCoordinator
 
     def __init__(
         self,
@@ -125,7 +128,7 @@ class XMLTVChannelSensor(XMLTVEntity, SensorEntity):
         }
 
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> str | None:
         """Return the native value of the sensor."""
         guide: TVGuide = self.coordinator.data
 
@@ -169,12 +172,18 @@ class XMLTVStatusSensor(XMLTVEntity, SensorEntity):
         :return: (translation_key, entity_id) tuple.
 
         """
+        assert guide.generator_name is not None, (
+            "XMLTVStatusSensor failed to create id, generator_name was None!"
+        )
+
         translation_key = "last_update"
         entity_id = (
             f"sensor.{normalize_for_entity_id(guide.generator_name)}_{translation_key}"
         )
 
         return translation_key, entity_id
+
+    coordinator: XMLTVDataUpdateCoordinator
 
     def __init__(self, coordinator: XMLTVDataUpdateCoordinator, guide: TVGuide) -> None:
         """Initialize the sensor class."""
@@ -217,7 +226,7 @@ class XMLTVStatusSensor(XMLTVEntity, SensorEntity):
         }
 
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> datetime | None:
         """Return the native value of the sensor."""
         coordinator: XMLTVDataUpdateCoordinator = self.coordinator
 
@@ -229,4 +238,7 @@ class XMLTVStatusSensor(XMLTVEntity, SensorEntity):
         self._guide = guide
 
         # native value is last update time
-        return coordinator.last_update_time.astimezone()
+        value = coordinator.last_update_time
+        if value is not None:
+            return value.astimezone()
+        return None

--- a/custom_components/xmltv_epg/sensor.py
+++ b/custom_components/xmltv_epg/sensor.py
@@ -117,6 +117,13 @@ class XMLTVChannelSensor(XMLTVEntity, SensorEntity):
         duration_hours = int(duration_seconds // 3600)
         duration_minutes = int((duration_seconds % 3600) // 60)
 
+        # get last program end time
+        last_program = self._channel.get_last_program()
+        if last_program is not None:
+            channel_program_known_until = last_program.end
+        else:
+            channel_program_known_until = None
+
         return {
             "start": program.start,
             "end": program.end,
@@ -125,6 +132,7 @@ class XMLTVChannelSensor(XMLTVEntity, SensorEntity):
             "description": program.description,
             "episode": program.episode,
             "subtitle": program.subtitle,
+            "channel_program_known_until": channel_program_known_until,
         }
 
     @property

--- a/custom_components/xmltv_epg/translations/de.json
+++ b/custom_components/xmltv_epg/translations/de.json
@@ -50,6 +50,9 @@
                     },
                     "subtitle": {
                         "name": "Untertitel"
+                    },
+                    "channel_program_known_until": {
+                        "name": "EPG verfügbar bis"
                     }
                 }
             },

--- a/custom_components/xmltv_epg/translations/en.json
+++ b/custom_components/xmltv_epg/translations/en.json
@@ -50,6 +50,9 @@
                     },
                     "subtitle": {
                         "name": "Subtitle"
+                    },
+                    "channel_program_known_until": {
+                        "name": "EPG available until"
                     }
                 }
             },

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "XMLTV EPG",
     "filename": "xmltv_epg.zip",
     "hide_default_branch": true,
-    "homeassistant": "2024.2.0",
+    "homeassistant": "2025.1.3",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-homeassistant==2024.2.0
+homeassistant==2025.1.3
 colorlog>=6.8.2
 ruff>=0.4.4
 pytest>=7.4.4

--- a/test/model/test_TVChannel.py
+++ b/test/model/test_TVChannel.py
@@ -72,3 +72,8 @@ def test_get_current_or_next_program():
     next = channel.get_next_program(datetime(2020, 1, 1, 1, 15))
     assert next is not None
     assert next.title == program_next.title
+
+    # last program entry is 'next'
+    last = channel.get_last_program()
+    assert last is not None
+    assert last.title == program_next.title

--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -5,8 +5,10 @@ from unittest.mock import PropertyMock, patch
 
 import pytest
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.xmltv_epg.api import XMLTVClient
+from custom_components.xmltv_epg.const import DOMAIN
 from custom_components.xmltv_epg.coordinator import XMLTVDataUpdateCoordinator
 
 from .const import MOCK_NOW, MOCK_TV_GUIDE, MOCK_TV_GUIDE_URL
@@ -32,9 +34,16 @@ async def test_coordinator_basic(
 ):
     """Test the basic functionality of the coordinator."""
 
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test",
+        data={},
+    )
+
     # create the coordinator
     coordinator = XMLTVDataUpdateCoordinator(
         hass,
+        config_entry=entry,
         client=XMLTVClient(
             session=async_get_clientsession(hass),
             url=MOCK_TV_GUIDE_URL,

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -5,7 +5,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.xmltv_epg import (
     async_reload_entry,
-    async_setup_entry,
     async_unload_entry,
 )
 from custom_components.xmltv_epg.const import DOMAIN
@@ -24,6 +23,7 @@ async def test_setup_unload_and_reload_entry(
         data={CONF_HOST: MOCK_TV_GUIDE_URL},
         entry_id="MOCK",
     )
+    config_entry.add_to_hass(hass)
 
     # helper to assert entry
     def assert_entry():
@@ -34,7 +34,8 @@ async def test_setup_unload_and_reload_entry(
         )
 
     # setup the entry
-    assert await async_setup_entry(hass, config_entry)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
     assert_entry()
 
     # should have called coordinator update

--- a/test/test_sensor.py
+++ b/test/test_sensor.py
@@ -59,6 +59,9 @@ async def test_sensors_basic(
         },
         entry_id="MOCK",
     )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     # setup the entry
     assert await async_setup_entry(hass, config_entry)
@@ -120,6 +123,9 @@ async def test_program_sensor_attributes(
         },
         entry_id="MOCK",
     )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     # setup the entry
     assert await async_setup_entry(hass, config_entry)
@@ -156,6 +162,9 @@ async def test_last_update_sensor_attributes(
         },
         entry_id="MOCK",
     )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     # setup the entry
     assert await async_setup_entry(hass, config_entry)


### PR DESCRIPTION
this PR:
- updates the homeassistant dependency all the way to 2025.1.3
- updates the devcontainer python version to 3.13
- updates github CI python version to 3.13
- removes some deprecated behaviour, as logged by homeassistant
- fixes a ton of small typing mishaps
- fixes failing unit tests due to updated homeassistant
- configures codecov to more sensible coverage target
- adds a "EPG available until" attribute to channel program sensors