### PR TITLE
Update/coordinator

### DIFF
--- a/custom_components/xmltv_epg/__init__.py
+++ b/custom_components/xmltv_epg/__init__.py
@@ -6,7 +6,7 @@ https://github.com/shadow578/homeassistant_xmltv-epg
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -56,16 +56,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             OPT_ENABLE_PROGRAM_IMAGES, DEFAULT_ENABLE_PROGRAM_IMAGES
         ),
     )
-    if entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
-        # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
-        await coordinator.async_config_entry_first_refresh()
-    else:
-        # To fix deprecation warning (???)
-        # Detected that custom integration 'xmltv_epg' uses `async_config_entry_first_refresh`, which is only supported when entry state is ConfigEntryState.SETUP_IN_PROGRESS, but it is in state ConfigEntryState.LOADED
-        await coordinator.async_refresh()
+
+    # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
+    await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    # FIXME for some reason, following the example for a coordinated single API poll, the
+    # sensors created in sensor.py don't display the data until the next refresh interval.
+    # causing a refresh manually after they are set up works around this issue.
+    # see https://developers.home-assistant.io/docs/integration_fetching_data/#coordinated-single-api-poll-for-data-for-all-entities
+    await coordinator.async_refresh()
 
     return True
 

--- a/custom_components/xmltv_epg/__init__.py
+++ b/custom_components/xmltv_epg/__init__.py
@@ -61,6 +61,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # listen for updates to the config entry to re-setup it
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     # FIXME for some reason, following the example for a coordinated single API poll, the
@@ -81,5 +83,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/xmltv_epg/coordinator.py
+++ b/custom_components/xmltv_epg/coordinator.py
@@ -21,11 +21,10 @@ from .const import DOMAIN, LOGGER, SENSOR_REFRESH_INTERVAL
 
 
 # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
-class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
+class XMLTVDataUpdateCoordinator(DataUpdateCoordinator[TVGuide]):
     """Class to manage fetching data from XMLTV."""
 
     config_entry: ConfigEntry
-    data: TVGuide
 
     __client: XMLTVClient
     __lookahead: timedelta
@@ -33,7 +32,7 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
     __enable_channel_icon: bool
     __enable_program_image: bool
 
-    __guide: TVGuide | None
+    __guide: TVGuide
     __last_refetch_time: datetime | None
     __refetch_interval: timedelta
 
@@ -63,7 +62,7 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
             config_entry=config_entry,
         )
 
-        self.__guide = None
+        self.__guide = TVGuide()
         self.__last_refetch_time = None
         self.__refetch_interval = timedelta(hours=update_interval)
 

--- a/custom_components/xmltv_epg/coordinator.py
+++ b/custom_components/xmltv_epg/coordinator.py
@@ -27,6 +27,16 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
     config_entry: ConfigEntry
     data: TVGuide
 
+    __client: XMLTVClient
+    __lookahead: timedelta
+    __enable_upcoming_sensor: bool
+    __enable_channel_icon: bool
+    __enable_program_image: bool
+
+    __guide: TVGuide | None
+    __last_refetch_time: datetime | None
+    __refetch_interval: timedelta
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -39,11 +49,11 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
         enable_program_image: bool,
     ) -> None:
         """Initialize."""
-        self.client = client
-        self._lookahead = timedelta(minutes=lookahead)
-        self._enable_upcoming_sensor = enable_upcoming_sensor
-        self._enable_channel_icon = enable_channel_icon
-        self._enable_program_image = enable_program_image
+        self.__client = client
+        self.__lookahead = timedelta(minutes=lookahead)
+        self.__enable_upcoming_sensor = enable_upcoming_sensor
+        self.__enable_channel_icon = enable_channel_icon
+        self.__enable_program_image = enable_program_image
 
         super().__init__(
             hass=hass,
@@ -53,31 +63,31 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
             config_entry=config_entry,
         )
 
-        self._guide = None
-        self._last_refetch_time = None
-        self._refetch_interval = timedelta(hours=update_interval)
+        self.__guide = None
+        self.__last_refetch_time = None
+        self.__refetch_interval = timedelta(hours=update_interval)
 
     async def _refetch_tv_guide(self):
         """Re-fetch TV guide data."""
         try:
-            guide = await self.client.async_get_data()
+            guide = await self.__client.async_get_data()
             LOGGER.debug(
                 f"Updated XMLTV guide /w {len(guide.channels)} channels and {len(guide.programs)} programs."
             )
 
-            self._guide = guide
-            self._last_refetch_time = self.actual_now
+            self.__guide = guide
+            self.__last_refetch_time = self.actual_now
         except XMLTVClientError as exception:
             raise UpdateFailed(exception) from exception
 
     def _should_refetch(self) -> bool:
         """Check if data should be refetched?."""
         # no guide data yet ?
-        if not self._guide or not self._last_refetch_time:
+        if not self.__guide or not self.__last_refetch_time:
             return True
 
         # check if refetch interval has passed
-        next_refetch_time = self._last_refetch_time + self._refetch_interval
+        next_refetch_time = self.__last_refetch_time + self.__refetch_interval
         return self.actual_now >= next_refetch_time
 
     async def _async_update_data(self):
@@ -85,7 +95,7 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
         if self._should_refetch():
             await self._refetch_tv_guide()
 
-        return self._guide
+        return self.__guide
 
     @property
     def actual_now(self) -> datetime:
@@ -95,24 +105,29 @@ class XMLTVDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def current_time(self) -> datetime:
         """Get effective current time."""
-        return self.actual_now + self._lookahead
+        return self.actual_now + self.__lookahead
 
     @property
     def last_update_time(self) -> datetime | None:
         """Get last update time."""
-        return self._last_refetch_time
+        return self.__last_refetch_time
 
     @property
     def enable_upcoming_sensor(self) -> bool:
         """Get enable upcoming sensor."""
-        return self._enable_upcoming_sensor
+        return self.__enable_upcoming_sensor
 
     @property
     def enable_channel_icon(self) -> bool:
         """Get enable channel icon entity."""
-        return self._enable_channel_icon
+        return self.__enable_channel_icon
 
     @property
     def enable_program_image(self) -> bool:
         """Get enable program image entities."""
-        return self._enable_program_image
+        return self.__enable_program_image
+
+    @property
+    def _last_refetch_time(self) -> datetime | None:
+        """Get last refetch time."""
+        return self.__last_refetch_time

--- a/custom_components/xmltv_epg/entity.py
+++ b/custom_components/xmltv_epg/entity.py
@@ -10,7 +10,7 @@ from .coordinator import XMLTVDataUpdateCoordinator
 from .model import TVChannel, TVGuide
 
 
-class XMLTVEntity(CoordinatorEntity):
+class XMLTVEntity(CoordinatorEntity[XMLTVDataUpdateCoordinator]):
     """XMLTV Entity class."""
 
     def __init__(

--- a/custom_components/xmltv_epg/image.py
+++ b/custom_components/xmltv_epg/image.py
@@ -9,6 +9,7 @@ from homeassistant.components.image import (
     ImageEntity,
     ImageEntityDescription,
 )
+from homeassistant.core import callback
 
 from .const import DOMAIN, LOGGER
 from .coordinator import XMLTVDataUpdateCoordinator
@@ -45,6 +46,10 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
 
     coordinator: XMLTVDataUpdateCoordinator
 
+    __channel: TVChannel
+    __program: TVProgram | None
+    __is_next: bool
+
     def __init__(
         self,
         coordinator: XMLTVDataUpdateCoordinator,
@@ -68,38 +73,41 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
             translation_key=translation_key,
         )
 
-        self._channel = channel
-        self._program = None
-        self._is_next = is_next
+        self.__channel = channel
+        self.__program = None
+        self.__is_next = is_next
 
         LOGGER.debug(f"Setup image '{self.entity_id}' for channel '{channel.id}'.")
 
-    @property
-    def __current_program(self) -> TVProgram | None:
-        """Refresh and return the current program object."""
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
         guide: TVGuide = self.coordinator.data
 
         # refresh channel from guide
-        channel = guide.get_channel(self._channel.id)
+        channel = guide.get_channel(self.__channel.id)
         if channel is None:
-            return None
+            self.__program = None
+            super()._handle_coordinator_update()
+            return
 
-        self._channel = channel
+        self.__channel = channel
 
         now = self.coordinator.current_time
 
         # get current or next program
-        self._program = (
-            self._channel.get_next_program(now)
-            if self._is_next
+        self.__program = (
+            self.__channel.get_next_program(now)
+            if self.__is_next
             else channel.get_current_program(now)
         )
-        return self._program
+
+        super()._handle_coordinator_update()
 
     @property
     def image_last_updated(self) -> datetime | None:
         """Time the image was last updated."""
-        program = self.__current_program
+        program = self.__program
         if program is None:
             return None
         return program.start
@@ -107,7 +115,7 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
     @property
     def image_url(self) -> str | None:
         """Return URL of image."""
-        program = self.__current_program
+        program = self.__program
         if program is None:
             return None
         return program.image_url
@@ -115,7 +123,7 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
     @property
     def state(self) -> str | None:
         """Get the state value of the image entity."""
-        program = self.__current_program
+        program = self.__program
         if program is None:
             return None
         return program.full_title
@@ -125,6 +133,10 @@ class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
     """XMLTV Channel Icon Image class."""
 
     coordinator: XMLTVDataUpdateCoordinator
+
+    __channel: TVChannel
+    __last_icon_url: str | None
+    __last_updated: datetime | None
 
     def __init__(
         self, coordinator: XMLTVDataUpdateCoordinator, channel: TVChannel
@@ -146,34 +158,33 @@ class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
             translation_key=translation_key,
         )
 
-        self._channel = channel
-        self._last_icon_url: str | None = None
-        self._last_updated: datetime | None = None
+        self.__channel = channel
+        self.__last_icon_url = None
+        self.__last_updated = None
 
         LOGGER.debug(f"Setup image '{self.entity_id}' for channel '{channel.id}'.")
 
-    @property
-    def __current_channel(self) -> TVChannel | None:
-        """Refresh and return the current channel object."""
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
         guide: TVGuide = self.coordinator.data
 
         # refresh channel from guide
-        channel = guide.get_channel(self._channel.id)
-        if channel is None:
-            return None
+        channel = guide.get_channel(self.__channel.id)
+        if channel is not None:
+            self.__channel = channel
 
-        self._channel = channel
-        return self._channel
+        super()._handle_coordinator_update()
 
     @property
     def image_last_updated(self) -> datetime | None:
         """Time the image was last updated."""
-        return self._last_updated
+        return self.__last_updated
 
     @property
     def image_url(self) -> str | None:
         """Return URL of image."""
-        channel = self.__current_channel
+        channel = self.__channel
         if channel is None:
             return None
 
@@ -181,16 +192,16 @@ class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
         if icon_url is None:
             return None
 
-        if icon_url != self._last_icon_url:
-            self._last_icon_url = icon_url
-            self._last_updated = self.coordinator.current_time
+        if icon_url != self.__last_icon_url:
+            self.__last_icon_url = icon_url
+            self.__last_updated = self.coordinator.current_time
 
         return icon_url
 
     @property
     def state(self) -> str | None:
         """Get the state value of the image entity."""
-        channel = self.__current_channel
+        channel = self.__channel
         if channel is None:
             return None
         return channel.name

--- a/custom_components/xmltv_epg/image.py
+++ b/custom_components/xmltv_epg/image.py
@@ -118,8 +118,6 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
             super()._handle_coordinator_update()
             return
 
-        self._attr_state = self.__program.full_title
-
         # update image
         image_url = self.__program.image_url
         if image_url is None:
@@ -187,8 +185,6 @@ class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
             return
 
         self.__channel = channel
-
-        self._attr_state = channel.name
 
         # update image
         icon_url = channel.icon_url

--- a/custom_components/xmltv_epg/image.py
+++ b/custom_components/xmltv_epg/image.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 from homeassistant.components.image import (
     ImageEntity,
@@ -79,6 +78,11 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
 
         LOGGER.debug(f"Setup image '{self.entity_id}' for channel '{channel.id}'.")
 
+    @property
+    def available(self) -> bool:  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+        """Return if entity is available."""
+        return XMLTVEntity.available.__get__(self)
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -88,6 +92,10 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
         channel = guide.get_channel(self.__channel.id)
         if channel is None:
             self.__program = None
+            self._attr_state = None
+            self._attr_image_url = None
+            self._attr_image_last_updated = self.coordinator.current_time
+
             super()._handle_coordinator_update()
             return
 
@@ -102,31 +110,29 @@ class XMLTVChannelProgramImage(XMLTVEntity, ImageEntity):
             else channel.get_current_program(now)
         )
 
+        if self.__program is None:
+            self._attr_state = None
+            self._attr_image_url = None
+            self._attr_image_last_updated = self.coordinator.current_time
+
+            super()._handle_coordinator_update()
+            return
+
+        self._attr_state = self.__program.full_title
+
+        # update image
+        image_url = self.__program.image_url
+        if image_url is None:
+            self._attr_image_url = None
+            self._attr_image_last_updated = self.coordinator.current_time
+
+            super()._handle_coordinator_update()
+            return
+
+        self._attr_image_url = image_url
+        self._attr_image_last_updated = self.coordinator.current_time
+
         super()._handle_coordinator_update()
-
-    @property
-    def image_last_updated(self) -> datetime | None:
-        """Time the image was last updated."""
-        program = self.__program
-        if program is None:
-            return None
-        return program.start
-
-    @property
-    def image_url(self) -> str | None:
-        """Return URL of image."""
-        program = self.__program
-        if program is None:
-            return None
-        return program.image_url
-
-    @property
-    def state(self) -> str | None:
-        """Get the state value of the image entity."""
-        program = self.__program
-        if program is None:
-            return None
-        return program.full_title
 
 
 class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
@@ -135,8 +141,6 @@ class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
     coordinator: XMLTVDataUpdateCoordinator
 
     __channel: TVChannel
-    __last_icon_url: str | None
-    __last_updated: datetime | None
 
     def __init__(
         self, coordinator: XMLTVDataUpdateCoordinator, channel: TVChannel
@@ -159,10 +163,13 @@ class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
         )
 
         self.__channel = channel
-        self.__last_icon_url = None
-        self.__last_updated = None
 
         LOGGER.debug(f"Setup image '{self.entity_id}' for channel '{channel.id}'.")
+
+    @property
+    def available(self) -> bool:  # pyright: ignore[reportIncompatibleVariableOverride] -- Entity.available and CoordinatorEntity.available are defined incompatible
+        """Return if entity is available."""
+        return XMLTVEntity.available.__get__(self)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -171,37 +178,28 @@ class XMLTVChannelIconImage(XMLTVEntity, ImageEntity):
 
         # refresh channel from guide
         channel = guide.get_channel(self.__channel.id)
-        if channel is not None:
-            self.__channel = channel
-
-        super()._handle_coordinator_update()
-
-    @property
-    def image_last_updated(self) -> datetime | None:
-        """Time the image was last updated."""
-        return self.__last_updated
-
-    @property
-    def image_url(self) -> str | None:
-        """Return URL of image."""
-        channel = self.__channel
         if channel is None:
-            return None
+            self._attr_state = None
+            self._attr_image_url = None
+            self._attr_image_last_updated = self.coordinator.current_time
 
+            super()._handle_coordinator_update()
+            return
+
+        self.__channel = channel
+
+        self._attr_state = channel.name
+
+        # update image
         icon_url = channel.icon_url
         if icon_url is None:
-            return None
+            self._attr_image_url = None
+            self._attr_image_last_updated = self.coordinator.current_time
 
-        if icon_url != self.__last_icon_url:
-            self.__last_icon_url = icon_url
-            self.__last_updated = self.coordinator.current_time
+            super()._handle_coordinator_update()
+            return
 
-        return icon_url
+        self._attr_image_url = icon_url
+        self._attr_image_last_updated = self.coordinator.current_time
 
-    @property
-    def state(self) -> str | None:
-        """Get the state value of the image entity."""
-        channel = self.__channel
-        if channel is None:
-            return None
-        return channel.name
+        super()._handle_coordinator_update()

--- a/custom_components/xmltv_epg/sensor.py
+++ b/custom_components/xmltv_epg/sensor.py
@@ -95,6 +95,7 @@ class XMLTVChannelSensor(XMLTVEntity, SensorEntity):
         if channel is None:
             self._attr_native_value = None
             self._attr_extra_state_attributes = {}
+
             super()._handle_coordinator_update()
             return
 
@@ -111,6 +112,8 @@ class XMLTVChannelSensor(XMLTVEntity, SensorEntity):
         if self.__program is None:
             self._attr_native_value = None
             self._attr_extra_state_attributes = {}
+
+            super()._handle_coordinator_update()
             return
 
         # native value is full program title

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -9,6 +9,8 @@
     "reportUnusedImport": true,
     "reportUnusedVariable": true,
     "reportGeneralTypeIssues": true,
+    "reportUnusedClass": true,
+    "reportUnusedFunction": true,
     "pythonVersion": "3.12",
-    "typeCheckingMode": "basic",
+    "typeCheckingMode": "standard",
 }

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -9,7 +9,6 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import device_registry, entity_registry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.xmltv_epg import async_setup_entry
 from custom_components.xmltv_epg.const import (
     DOMAIN,
     OPT_ENABLE_CHANNEL_ICONS,
@@ -89,10 +88,6 @@ async def test_images_basic(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # setup the entry
-    assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
 
     # create client
@@ -186,10 +181,6 @@ async def test_program_sensor_device(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # setup the entry
-    assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
 
     # get device entry for CH3 current image

--- a/test/test_sensor.py
+++ b/test/test_sensor.py
@@ -8,7 +8,6 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import device_registry, entity_registry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.xmltv_epg import async_setup_entry
 from custom_components.xmltv_epg.const import (
     DOMAIN,
     OPT_ENABLE_UPCOMING_SENSOR,
@@ -63,10 +62,6 @@ async def test_sensors_basic(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # setup the entry
-    assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
 
     # last_update sensor should be created
@@ -129,10 +124,6 @@ async def test_program_sensor_attributes(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # setup the entry
-    assert await async_setup_entry(hass, config_entry)
-    await hass.async_block_till_done()
-
     # check CH 3 Current sensor attributes match the program
     state = hass.states.get("sensor.mock_3_program_current")
     assert state
@@ -168,10 +159,6 @@ async def test_program_sensor_device(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # setup the entry
-    assert await async_setup_entry(hass, config_entry)
-    await hass.async_block_till_done()
-
     # get device entry for CH3 current sensor
     er = entity_registry.async_get(hass)
     dr = device_registry.async_get(hass)
@@ -204,10 +191,6 @@ async def test_last_update_sensor_attributes(
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # setup the entry
-    assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
 
     # check sensor attributes


### PR DESCRIPTION
backport of https://github.com/shadow578/homeassistant_sma-ennexos/pull/41 and pyright changes of https://github.com/shadow578/homeassistant_sma-ennexos/pull/44.

as part of increasing the typechecking level, the custom state values for the image entities were removed and instead follow the homeassistant default of showing the last update time.