### PR TITLE
Update program.py

### DIFF
--- a/custom_components/xmltv_epg/model/program.py
+++ b/custom_components/xmltv_epg/model/program.py
@@ -106,7 +106,7 @@ class TVProgram(BaseXmlModel, tag="programme", search_mode="ordered"):
         """
         if isinstance(value, date):
             return value
-            
+
         value = value.strip()
 
         # Tunarr (and some other sources) emit full datetime format

--- a/custom_components/xmltv_epg/model/program.py
+++ b/custom_components/xmltv_epg/model/program.py
@@ -106,8 +106,13 @@ class TVProgram(BaseXmlModel, tag="programme", search_mode="ordered"):
         """
         if isinstance(value, date):
             return value
-
+            
         value = value.strip()
+
+        # Tunarr (and some other sources) emit full datetime format
+        # e.g. "19960217000000 +0000" — truncate to date portion
+        if len(value) > 8:
+            value = value[:8]
 
         if len(value) == 8:  # YYYYMMDD
             return datetime.strptime(value, "%Y%m%d").date()

--- a/test/model/test_TVProgram.py
+++ b/test/model/test_TVProgram.py
@@ -221,6 +221,22 @@ def test_parse_program_release_date_partial_dates():
     assert program.release_date == date(1990, 1, 1)
 
 
+def test_parse_program_release_date_full_datetime():
+    """Test TVProgram.from_xml method parses date attribute with full datetime strings correctly."""
+    xml = """
+    <programme start="20200101010000 +0000" stop="20200101020000 +0000" channel="CH1">
+        <title>Program 1</title>
+        <desc>Description 1</desc>
+        <date>19960217000000 +0000</date>
+    </programme>
+    """
+
+    program = TVProgram.from_xml(xml)
+    assert program is not None
+
+    assert program.release_date == date(1996, 2, 17)
+
+
 def test_parse_program_language():
     """Test TVProgram.from_xml method parses language attribute correctly."""
     xml = """


### PR DESCRIPTION
Full disclosure found this bug with Claude AI. Had it write up the summary below. Love the app very useful just wanted to share what fixed it for me. Thank you!

All programmes are silently dropped when the XMLTV `<date>` field contains a full  datetime string (e.g. `19960217000000 +0000`) instead of a simple date (YYYYMMDD).  This causes all channel current/upcoming program sensors to show `unavailable`.

The issue manifests as gradual degradation — channels that initially work start  losing programme data as more content with populated date metadata is added to the  source library.